### PR TITLE
Add .pushplayignore to exclude build artifacts

### DIFF
--- a/.pushplayignore
+++ b/.pushplayignore
@@ -1,0 +1,33 @@
+node_modules/
+dist/
+.turbo/
+reports/
+*.db
+*.db-shm
+*.db-wal
+*.db.pid
+corpus/
+adversarial-harness/
+security-swarm/
+benchmarks/
+assets/
+installer/
+*.tgz
+coverage/
+test-results/
+corpus-eval-report.json
+benchmark-report.json
+.threat-state.json
+.ai-learning.json
+
+# Python harness
+.venv/
+adversarial-harness/python/
+
+# Dashboard build artifacts
+deploy/dashboard-spa/node_modules/
+deploy/dashboard-spa/out/
+deploy/dashboard-spa/.next/
+
+# Pnpm
+pnpm-lock.yaml


### PR DESCRIPTION
This adds a .pushplayignore file to exclude node_modules (678MB), dist, reports, and other build artifacts from Pushplay.dev indexing. This prevents the indexing from timing out on large repos.