### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled command line

### DIFF
--- a/src/utils/token-counter.ts
+++ b/src/utils/token-counter.ts
@@ -11,7 +11,6 @@ import { get_encoding, type TiktokenEncoding } from 'tiktoken';
 import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { createRequire } from 'module';
-import https from 'https';
 import { Logger } from './logger.js';
 
 const requireOptional = createRequire(import.meta.url);

--- a/src/utils/token-counter.ts
+++ b/src/utils/token-counter.ts
@@ -8,9 +8,10 @@
  * - API usage: prefers usage.input_tokens / output_tokens from responses
  */
 import { get_encoding, type TiktokenEncoding } from 'tiktoken';
-import { execSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { createRequire } from 'module';
+import https from 'https';
 import { Logger } from './logger.js';
 
 const requireOptional = createRequire(import.meta.url);
@@ -458,19 +459,67 @@ export class TokenCounter {
     if (!apiKey) return null;
 
     try {
-      const result = execSync(
-        `curl -s --max-time 5 https://api.anthropic.com/v1/messages/count_tokens \\
-          -H "x-api-key: ${apiKey}" \\
-          -H "anthropic-version: 2023-06-01" \\
-          -H "content-type: application/json" \\
-          -d '${JSON.stringify({
-            model,
-            messages: [{ role: 'user', content: text }],
-          }).replace(/'/g, "'\\''")}'`,
-        { encoding: 'utf-8', timeout: 6000 },
-      );
+      const payload = JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: text }],
+      });
 
-      const data = JSON.parse(result);
+      const workerScript = `
+const https = require('https');
+const payload = process.env.ANTHROPIC_PAYLOAD;
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!payload || !apiKey) {
+  process.stderr.write('Missing payload or API key');
+  process.exit(1);
+}
+const req = https.request(
+  {
+    hostname: 'api.anthropic.com',
+    port: 443,
+    path: '/v1/messages/count_tokens',
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(payload),
+    },
+    timeout: 6000,
+  },
+  (res) => {
+    let data = '';
+    res.on('data', (chunk) => { data += chunk.toString('utf-8'); });
+    res.on('end', () => {
+      process.stdout.write(data);
+    });
+  }
+);
+req.on('timeout', () => {
+  req.destroy(new Error('timeout'));
+});
+req.on('error', (err) => {
+  process.stderr.write(String(err && err.message ? err.message : err));
+  process.exit(1);
+});
+req.write(payload);
+req.end();
+`;
+
+      const child = spawnSync(process.execPath, ['-e', workerScript], {
+        encoding: 'utf-8',
+        timeout: 6500,
+        env: {
+          ...process.env,
+          ANTHROPIC_API_KEY: apiKey,
+          ANTHROPIC_PAYLOAD: payload,
+        },
+      });
+
+      if (child.status !== 0) {
+        throw new Error(child.stderr || `anthropic counter subprocess failed with status ${String(child.status)}`);
+      }
+
+      const data = JSON.parse(child.stdout || '{}');
       if (data?.input_tokens !== undefined) {
         return {
           tokens: data.input_tokens,


### PR DESCRIPTION
Potential fix for [https://github.com/mastyf-ai/mastyf.ai/security/code-scanning/30](https://github.com/mastyf-ai/mastyf.ai/security/code-scanning/30)

General fix: avoid `execSync`/shell command strings for network calls; use a direct HTTP client API (`https.request` / `fetch`) or process execution API that does not invoke a shell. Here, the best minimal-risk fix is to replace the curl shell call in `anthropicCountApi` with a native HTTPS POST request implemented via Node’s `https` module.

Best single approach (without changing functionality):  
In `src/utils/token-counter.ts`:

1. Add `import https from 'https';`.
2. Replace `anthropicCountApi(...)` with a safe implementation using `https.request` and JSON body, preserving:
   - same endpoint: `https://api.anthropic.com/v1/messages/count_tokens`
   - same headers (`x-api-key`, `anthropic-version`, `content-type`)
   - similar timeout behavior (~6s)
   - same return shape (`TokenCountResult | null`)
   - same error logging behavior
3. Since the original method is synchronous and called from synchronous flow, implement a small synchronous wrapper by performing the HTTPS request in a spawned Node subprocess using `spawnSync(process.execPath, ['-e', script], ...)` with **argument/environment passing** (no shell). This keeps current call graph synchronous while removing command-line injection risk.

This change is localized to `src/utils/token-counter.ts` around imports and the `anthropicCountApi` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
