### PR TITLE
Fix Policy Suggestions accept/reject not updating the pending queue.

### DIFF
--- a/deploy/dashboard-spa/app/components/AiLearningPanel.tsx
+++ b/deploy/dashboard-spa/app/components/AiLearningPanel.tsx
@@ -97,9 +97,9 @@ export function AiLearningPanel({ roles, refreshTick = 0, onAction, onOpenThreat
       onAction?.('Requires operator role');
       return;
     }
-    const ok = await acceptSuggestion(s);
-    onAction?.(ok ? `Accepted ${s.ruleName || s.id}` : 'Accept failed');
-    if (ok) await refresh();
+    const res = await acceptSuggestion(s);
+    onAction?.(res.ok ? `Accepted ${s.ruleName || s.id}` : res.error || 'Accept failed');
+    if (res.ok) await refresh();
   };
 
   const onReject = async (s: AiSuggestion) => {
@@ -107,9 +107,9 @@ export function AiLearningPanel({ roles, refreshTick = 0, onAction, onOpenThreat
       onAction?.('Requires operator role');
       return;
     }
-    const ok = await rejectSuggestion(s);
-    onAction?.(ok ? `Rejected ${s.ruleName || s.id}` : 'Reject failed');
-    if (ok) await refresh();
+    const res = await rejectSuggestion(s);
+    onAction?.(res.ok ? `Rejected ${s.ruleName || s.id}` : res.error || 'Reject failed');
+    if (res.ok) await refresh();
   };
 
   const onLabel = async (id: string, label: 'true_positive' | 'false_positive' | 'ignored') => {

--- a/deploy/dashboard-spa/app/components/operations/SocAiLearningView.tsx
+++ b/deploy/dashboard-spa/app/components/operations/SocAiLearningView.tsx
@@ -119,18 +119,18 @@ export function SocAiLearningView({ roles = [], refreshKey, aiRefreshTick = 0, o
   const onAccept = async (s: AiSuggestion) => {
     if (!canMutate) { onAction?.('Requires operator role'); return; }
     setBusy(`accept:${s.id}`);
-    const ok = await acceptSuggestion(s);
-    onAction?.(ok ? `Accepted ${s.ruleName || s.id}` : 'Accept failed');
-    if (ok) await load();
+    const res = await acceptSuggestion(s);
+    onAction?.(res.ok ? `Accepted ${s.ruleName || s.id}` : res.error || 'Accept failed');
+    if (res.ok) await load();
     setBusy('');
   };
 
   const onReject = async (s: AiSuggestion) => {
     if (!canMutate) { onAction?.('Requires operator role'); return; }
     setBusy(`reject:${s.id}`);
-    const ok = await rejectSuggestion(s);
-    onAction?.(ok ? `Rejected ${s.ruleName || s.id}` : 'Reject failed');
-    if (ok) await load();
+    const res = await rejectSuggestion(s);
+    onAction?.(res.ok ? `Rejected ${s.ruleName || s.id}` : res.error || 'Reject failed');
+    if (res.ok) await load();
     setBusy('');
   };
 

--- a/deploy/dashboard-spa/lib/mastyf-ai-api.ts
+++ b/deploy/dashboard-spa/lib/mastyf-ai-api.ts
@@ -1320,7 +1320,9 @@ export async function investigateIncident(triggerId: string): Promise<Investigat
   return { investigation: (await res.json()) as Record<string, unknown> };
 }
 
-export async function acceptSuggestion(suggestion: AiSuggestion): Promise<boolean> {
+export type SuggestionActionResult = { ok: boolean; error?: string };
+
+export async function acceptSuggestion(suggestion: AiSuggestion): Promise<SuggestionActionResult> {
   const headers = await buildMutatingHeaders();
   const res = await mastyfAiFetch('/api/policy/suggestions/accept', {
     method: 'POST',
@@ -1333,10 +1335,25 @@ export async function acceptSuggestion(suggestion: AiSuggestion): Promise<boolea
       rule: suggestion.rule,
     }),
   });
-  return res.ok;
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      reason?: string;
+      blockers?: string[];
+    };
+    if (data.error === 'autopilot_safety_blocked') {
+      const blockers = Array.isArray(data.blockers) ? data.blockers.join('; ') : '';
+      return {
+        ok: false,
+        error: blockers ? `Safety blocked: ${blockers}` : 'Autopilot safety blocked this suggestion',
+      };
+    }
+    return { ok: false, error: data.reason || data.error || `Accept failed (HTTP ${res.status})` };
+  }
+  return { ok: true };
 }
 
-export async function rejectSuggestion(suggestion: AiSuggestion): Promise<boolean> {
+export async function rejectSuggestion(suggestion: AiSuggestion): Promise<SuggestionActionResult> {
   const headers = await buildMutatingHeaders();
   const res = await mastyfAiFetch('/api/policy/suggestions/reject', {
     method: 'POST',
@@ -1348,7 +1365,11 @@ export async function rejectSuggestion(suggestion: AiSuggestion): Promise<boolea
       confidence: suggestion.confidence ?? 0.5,
     }),
   });
-  return res.ok;
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string; reason?: string };
+    return { ok: false, error: data.reason || data.error || `Reject failed (HTTP ${res.status})` };
+  }
+  return { ok: true };
 }
 
 export async function reloadPolicy(): Promise<boolean> {

--- a/src/ai/suggestion-engine.ts
+++ b/src/ai/suggestion-engine.ts
@@ -581,6 +581,44 @@ export async function ensureAiEngineInitialized(
   return initializeAiEngine(db, resolved);
 }
 
+/** Remove a suggestion from the pending queue after accept/reject. */
+export function removePendingSuggestion(
+  suggestionId: string,
+  opts?: { ruleName?: string; tenantId?: string },
+): boolean {
+  try {
+    const path = resolveAiPendingSuggestionsPath(opts?.tenantId);
+    if (!existsSync(path)) return false;
+    const body = JSON.parse(readFileSync(path, 'utf-8')) as {
+      updatedAt?: string;
+      suggestions?: Array<{ id: string; ruleName?: string }>;
+    };
+    const before = body.suggestions?.length ?? 0;
+    const id = suggestionId.trim();
+    const ruleName = opts?.ruleName?.trim();
+    body.suggestions = (body.suggestions ?? []).filter(
+      (s) => s.id !== id && (!ruleName || s.ruleName !== ruleName),
+    );
+    if (body.suggestions.length === before) return false;
+    body.updatedAt = new Date().toISOString();
+    writeFileSync(path, JSON.stringify(body, null, 2));
+    void import('../utils/metrics.js').then(({ setSuggestionQueueDepth }) => {
+      setSuggestionQueueDepth(body.suggestions!.length);
+    });
+    broadcastDashboardEvent({
+      type: 'ai:suggestions',
+      payload: { suggestions: body.suggestions, removed: id },
+      timestamp: Date.now(),
+    });
+    return true;
+  } catch (err: unknown) {
+    Logger.debug(
+      `[SuggestionEngine] Failed to remove pending suggestion: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
 /** Read persisted pending suggestions (fast — no learning cycle). */
 export function loadPendingSuggestions(tenantId?: string): Array<{
   id: string;
@@ -751,6 +789,7 @@ export async function recordSuggestionOutcome(
     policyWatcher?: PolicyWatcher | null;
     userId?: string;
     pattern?: string;
+    tenantId?: string;
   },
 ): Promise<void> {
   const patterns = meta.pattern || meta.rule?.argPatterns?.join(' ');
@@ -758,6 +797,8 @@ export async function recordSuggestionOutcome(
     const { applySuggestionToPolicy } = await import('./policy-applier.js');
     await applySuggestionToPolicy(meta.rule, meta.policyPath, meta.policyWatcher ?? null);
   }
+
+  removePendingSuggestion(suggestionId, { ruleName: meta.ruleName, tenantId: meta.tenantId });
 
   if (globalEngine) {
     globalEngine.recordUserOutcome(suggestionId, action, {

--- a/src/utils/dashboard-server.ts
+++ b/src/utils/dashboard-server.ts
@@ -3173,7 +3173,17 @@ export async function startDashboardServer(
       if (url === '/api/policy/suggestions/accept' && method === 'POST') {
         setCors();
         const b = await readBody(req);
-        const rule = b.rule as import('../policy/policy-types.js').PolicyRule | undefined;
+        let rule = b.rule as import('../policy/policy-types.js').PolicyRule | undefined;
+        if (!rule?.name || !rule?.action) {
+          const { loadPendingSuggestions } = await import('../ai/suggestion-engine.js');
+          const found = loadPendingSuggestions(requestTenantId).find(
+            (s) => s.id === String(b.suggestionId || '')
+              || (!!b.ruleName && s.ruleName === String(b.ruleName)),
+          );
+          if (found?.rule?.name && found.rule.action) {
+            rule = found.rule;
+          }
+        }
         if (!rule?.name || !rule?.action) {
           writeJson(res, 400, { error: 'invalid_rule', reason: 'rule.name and rule.action are required' });
           return;
@@ -3215,6 +3225,7 @@ export async function startDashboardServer(
           policyPath,
           policyWatcher: policyWatcher ?? null,
           userId: authResult.identity || String(b.userId || ''),
+          tenantId: requestTenantId,
         });
         const { appendLearningEvent } = await import('./learning-events.js');
         appendLearningEvent({
@@ -3306,6 +3317,7 @@ export async function startDashboardServer(
           confidence: typeof b2.confidence === 'number' ? b2.confidence : 0.5,
           userId: authResult.identity || String(b2.userId || ''),
           pattern: b2.pattern ? String(b2.pattern) : undefined,
+          tenantId: requestTenantId,
         });
         if (b2.fpReject && b2.rule && b2.pattern) {
           const { recordFpRejection } = await import('../ai/fp-whitelist.js');

--- a/tests/ai/pending-suggestions.test.ts
+++ b/tests/ai/pending-suggestions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  loadPendingSuggestions,
+  removePendingSuggestion,
+  recordSuggestionOutcome,
+} from '../../src/ai/suggestion-engine.js';
+
+describe('pending suggestions queue', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mastyf-pending-'));
+    process.env.MASTYF_AI_AI_SUGGESTIONS_PATH = join(dir, '.ai-pending-suggestions.json');
+    writeFileSync(process.env.MASTYF_AI_AI_SUGGESTIONS_PATH, JSON.stringify({
+      updatedAt: new Date().toISOString(),
+      suggestions: [
+        {
+          id: 'attack-1',
+          ruleName: 'attack-learned-read_file',
+          rule: { name: 'attack-learned-read_file', action: 'block', patterns: ['.*'] },
+          confidence: 0.9,
+          reason: 'test',
+          source: 'attack',
+        },
+        {
+          id: 'baseline-2',
+          ruleName: 'baseline-anomaly',
+          rule: { name: 'baseline-anomaly', action: 'flag' },
+          confidence: 0.7,
+          reason: 'test',
+          source: 'baseline',
+        },
+      ],
+    }, null, 2));
+  });
+
+  afterEach(() => {
+    delete process.env.MASTYF_AI_AI_SUGGESTIONS_PATH;
+  });
+
+  it('removePendingSuggestion drops by id', () => {
+    expect(removePendingSuggestion('attack-1')).toBe(true);
+    const pending = loadPendingSuggestions();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe('baseline-2');
+  });
+
+  it('recordSuggestionOutcome removes rejected items from the queue', async () => {
+    await recordSuggestionOutcome('baseline-2', 'rejected', {
+      ruleName: 'baseline-anomaly',
+      source: 'baseline',
+      confidence: 0.7,
+    });
+    const pending = loadPendingSuggestions();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe('attack-1');
+    const raw = JSON.parse(readFileSync(process.env.MASTYF_AI_AI_SUGGESTIONS_PATH!, 'utf-8'));
+    expect(raw.suggestions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Remove suggestions from the persisted queue after apply or dismiss so the dashboard refreshes correctly, resolve rules from pending when the client omits them, and surface API errors in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches policy accept/reject and persisted suggestion queue with tenant-scoped paths; behavior change is intentional but affects operator policy workflows.
> 
> **Overview**
> Fixes policy suggestion **accept/reject** so the dashboard pending list actually updates and failures are visible to operators.
> 
> **Backend:** Adds `removePendingSuggestion` to drop entries from the persisted `.ai-pending-suggestions.json` queue (updates metrics and broadcasts `ai:suggestions`). `recordSuggestionOutcome` now calls it on both apply and reject, with **tenantId** passed from the dashboard API. The accept handler **backfills `rule` from the pending queue** when the client omits it, so accepts can succeed without a full rule payload in the POST body.
> 
> **Client:** `acceptSuggestion` / `rejectSuggestion` return `{ ok, error? }` instead of a boolean, including a dedicated message for `autopilot_safety_blocked`. **Ai Learning** and **SOC AI Learning** panels show `res.error` and only refresh when `res.ok`.
> 
> **Tests:** Vitest coverage for `removePendingSuggestion` and queue removal on reject via `recordSuggestionOutcome`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2db3d74098dc9b92e02e1e519d8d88bd9b824c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->