### PR TITLE
Fix security threat quarantine restore and bulk archive behavior.

### DIFF
--- a/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
+++ b/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
@@ -266,7 +266,16 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
             {loading ? (
               <p className="text-sm text-muted">Loading threats…</p>
             ) : !dash?.threats || dash.threats.length === 0 ? (
-              <EmptyState title="No threats" message="All clear — no active threats detected" />
+              <EmptyState
+                title="No active threats"
+                message={
+                  (dash?.quarantinedCount ?? 0) > 0
+                    ? `${dash.quarantinedCount} threat(s) are quarantined and hidden from this list. Open Security → Quarantine and click Restore to show them here again.`
+                    : (dash?.executiveSummary?.[0]?.includes('policy blocks')
+                      ? 'Blocks are recorded in the window above, but no high-severity threat rows are in the monitor queue.'
+                      : 'All clear — no active threats detected in the selected time window.')
+                }
+              />
             ) : (
               <div className="table-wrap">
                 <table className="table">

--- a/deploy/dashboard-spa/lib/mastyf-ai-api.ts
+++ b/deploy/dashboard-spa/lib/mastyf-ai-api.ts
@@ -2293,6 +2293,7 @@ export type SecurityDashboardResponse = {
   executiveSummary?: string[];
   threats?: SecurityDashboardThreat[];
   activeThreatCount?: number;
+  quarantinedCount?: number;
   semanticEngineActive?: boolean;
   autoBlockOn?: boolean;
   auditLatencyMs?: number | null;

--- a/src/utils/dashboard-server.ts
+++ b/src/utils/dashboard-server.ts
@@ -2493,17 +2493,18 @@ export async function startDashboardServer(
         }
         try {
           const { getSecurityThreatQuarantine } = await import('./security-threat-quarantine.js');
-          const result = getSecurityThreatQuarantine(requestTenantId).restore(threatKey);
+          const result = getSecurityThreatQuarantine(requestTenantId).restoreGroup(threatKey);
           if (!result.ok) {
             writeJson(res, 400, { ok: false, error: result.error || 'Restore failed' });
             return;
           }
+          const primary = result.records?.[0];
           let removedRule = false;
-          if (removeRule && result.record?.appliedRuleName) {
+          if (removeRule && primary?.appliedRuleName) {
             const { removeSuggestionRuleFromPolicy } = await import('../ai/policy-applier.js');
             const removed = removeSuggestionRuleFromPolicy(
-              result.record.appliedRuleName,
-              result.record.policyPath || defaultPolicyPath(),
+              primary.appliedRuleName,
+              primary.policyPath || defaultPolicyPath(),
               policyWatcher ?? null,
             );
             removedRule = removed.removed;
@@ -2511,14 +2512,19 @@ export async function startDashboardServer(
           appendThreatIntelActionAudit({
             action: 'monitor_restore',
             id: threatKey,
-            appliedRuleName: result.record?.appliedRuleName,
+            appliedRuleName: primary?.appliedRuleName,
             removeRule,
             removedRule,
             operator: authResult.identity || null,
             tenantId: requestTenantId,
             timestamp: new Date().toISOString(),
           });
-          writeJson(res, 200, { ok: true, threatKey, removedRule });
+          writeJson(res, 200, {
+            ok: true,
+            threatKey,
+            removedRule,
+            restored: result.restored ?? 1,
+          });
         } catch (e) {
           writeJson(res, 500, { ok: false, error: e instanceof Error ? e.message : 'Restore failed' });
         }
@@ -2539,7 +2545,6 @@ export async function startDashboardServer(
 
           if (b.all === true || b.all === 'true') {
             const fed = await resolveChartContext(requestTenantId, 1);
-            const { buildSecurityDashboard } = await import('./security-dashboard.js');
             let policyMode: string | undefined;
             try {
               const { readFileSync } = await import('fs');
@@ -2550,12 +2555,24 @@ export async function startDashboardServer(
             } catch {
               policyMode = process.env.MASTYF_AI_POLICY_MODE;
             }
+            const { buildSecurityDashboard, listMonitorThreatCandidates, threatDisplayFingerprint } =
+              await import('./security-dashboard.js');
             const dash = await buildSecurityDashboard(fed.db, requestTenantId, 1, { policyMode });
-            const targets = (dash.threats ?? []).filter(
+            const visibleHigh = (dash.threats ?? []).filter(
               (t) => t.severity === 'critical' || t.severity === 'high',
             );
+            const targetFingerprints = new Set(
+              visibleHigh.map((t) => threatDisplayFingerprint(t)),
+            );
+            const allCandidates = await listMonitorThreatCandidates(fed.db, requestTenantId, 1);
+            const targetsByKey = new Map<string, (typeof allCandidates)[number]>();
+            for (const row of allCandidates) {
+              if (row.severity !== 'critical' && row.severity !== 'high') continue;
+              if (!targetFingerprints.has(threatDisplayFingerprint(row))) continue;
+              targetsByKey.set(row.threatKey, row);
+            }
             let quarantined = 0;
-            for (const row of targets) {
+            for (const row of targetsByKey.values()) {
               const enforcement = await applyMonitorQuarantineEnforcement({
                 row,
                 tenantId: requestTenantId,
@@ -2602,31 +2619,45 @@ export async function startDashboardServer(
               : 'blocked') as 'blocked' | 'monitored' | 'resolved',
           };
           const fed = await resolveChartContext(requestTenantId, 1);
-          const enforcement = await applyMonitorQuarantineEnforcement({
-            row,
-            tenantId: requestTenantId,
-            db: fed.db,
-            policyPath,
-            policyWatcher: policyWatcher ?? null,
-            operator,
-          });
-          const result = store.quarantine(row, operator, b.note ? String(b.note) : undefined, {
-            appliedRuleName: enforcement.appliedRuleName,
-            policyPath: enforcement.policyPath,
-            enforcementStatus: enforcement.status,
-            enforcementDetail: enforcement.detail,
-            sourceKind: enforcement.sourceKind,
-          });
-          if (!result.ok) {
-            writeJson(res, 400, { ok: false, error: result.error || 'Quarantine failed' });
-            return;
+          const { listMonitorThreatCandidates, threatDisplayFingerprint } =
+            await import('./security-dashboard.js');
+          const fingerprint = threatDisplayFingerprint(row);
+          const related = (await listMonitorThreatCandidates(fed.db, requestTenantId, 1)).filter(
+            (candidate) => threatDisplayFingerprint(candidate) === fingerprint,
+          );
+          const targets = related.length > 0 ? related : [row];
+          let lastEnforcement: Awaited<ReturnType<typeof applyMonitorQuarantineEnforcement>> | null =
+            null;
+          let lastResult: ReturnType<typeof store.quarantine> | null = null;
+          for (const target of targets) {
+            const enforcement = await applyMonitorQuarantineEnforcement({
+              row: target,
+              tenantId: requestTenantId,
+              db: fed.db,
+              policyPath,
+              policyWatcher: policyWatcher ?? null,
+              operator,
+            });
+            const result = store.quarantine(target, operator, b.note ? String(b.note) : undefined, {
+              appliedRuleName: enforcement.appliedRuleName,
+              policyPath: enforcement.policyPath,
+              enforcementStatus: enforcement.status,
+              enforcementDetail: enforcement.detail,
+              sourceKind: enforcement.sourceKind,
+            });
+            if (!result.ok) {
+              writeJson(res, 400, { ok: false, error: result.error || 'Quarantine failed' });
+              return;
+            }
+            lastEnforcement = enforcement;
+            lastResult = result;
           }
           appendThreatIntelActionAudit({
             action: 'monitor_quarantine',
             id: row.id,
             threatKey,
-            appliedRuleName: enforcement.appliedRuleName,
-            enforcementStatus: enforcement.status,
+            appliedRuleName: lastEnforcement?.appliedRuleName,
+            enforcementStatus: lastEnforcement?.status,
             operator: authResult.identity || null,
             tenantId: requestTenantId,
             timestamp: new Date().toISOString(),
@@ -2634,9 +2665,10 @@ export async function startDashboardServer(
           writeJson(res, 200, {
             ok: true,
             threatKey,
-            record: result.record,
-            appliedRuleName: enforcement.appliedRuleName,
-            enforcementStatus: enforcement.status,
+            record: lastResult?.record,
+            appliedRuleName: lastEnforcement?.appliedRuleName,
+            enforcementStatus: lastEnforcement?.status,
+            quarantined: targets.length,
           });
         } catch (e) {
           writeJson(res, 500, { ok: false, error: e instanceof Error ? e.message : 'Quarantine failed' });

--- a/src/utils/security-dashboard.ts
+++ b/src/utils/security-dashboard.ts
@@ -41,6 +41,7 @@ export type SecurityDashboardPayload = {
   executiveSummary: string[];
   threats: SecurityThreatRow[];
   activeThreatCount: number;
+  quarantinedCount: number;
   semanticEngineActive: boolean;
   autoBlockOn: boolean;
   auditLatencyMs: number | null;
@@ -95,6 +96,13 @@ function blockThreatKey(r: ProxyCallRecord): string {
   return `block:${r.serverName}:${r.toolName}:${r.timestamp || ''}`;
 }
 
+/** Stable UI grouping key — multiple block/semantic rows can share type+source. */
+export function threatDisplayFingerprint(
+  row: Pick<SecurityThreatRow, 'type' | 'source'>,
+): string {
+  return `${row.type}:${row.source}`;
+}
+
 function buildThreatsFromRecords(blocked: ProxyCallRecord[]): SecurityThreatRow[] {
   return blocked.slice(0, 20).map((r, i) => ({
     id: threatIdFromRecord(r, i),
@@ -120,6 +128,59 @@ async function buildThreatsFromSemantic(
       severity: (r.semanticAudit?.confidence ?? 0) >= 0.85 ? 'critical' : 'high',
       status: r.syncDecision?.action === 'block' ? 'blocked' : 'monitored',
     }));
+}
+
+async function gatherThreatCandidates(
+  db: IDatabase,
+  tenantId: string | undefined,
+  windowDays: number,
+): Promise<SecurityThreatRow[]> {
+  const records = await loadAllRecordsInWindow(db, tenantId, windowDays);
+  const blocked = records.filter((r) => r.blocked);
+  const semanticThreats = await buildThreatsFromSemantic(tenantId);
+  const recordThreats = buildThreatsFromRecords(blocked);
+  return [...semanticThreats, ...recordThreats];
+}
+
+/** All monitor threat rows before quarantine / dedupe (for bulk quarantine expansion). */
+export async function listMonitorThreatCandidates(
+  db: IDatabase | null,
+  tenantId: string | undefined,
+  windowDaysInput: number | string,
+): Promise<SecurityThreatRow[]> {
+  if (!db) return [];
+  const windowDays = parseWindowDays(windowDaysInput);
+  return gatherThreatCandidates(db, tenantId, windowDays);
+}
+
+/** @internal Exported for unit tests — dedupe + quarantine suppression. */
+export function filterVisibleMonitorThreats(
+  candidates: SecurityThreatRow[],
+  quarantine: ReturnType<typeof getSecurityThreatQuarantine>,
+): SecurityThreatRow[] {
+  return applyThreatVisibilityFilter(candidates, quarantine);
+}
+
+function applyThreatVisibilityFilter(
+  candidates: SecurityThreatRow[],
+  quarantine: ReturnType<typeof getSecurityThreatQuarantine>,
+): SecurityThreatRow[] {
+  const suppressedKeys = quarantine.quarantinedKeys();
+  const suppressedFingerprints = new Set(
+    quarantine.list(365).map((e) => threatDisplayFingerprint(e)),
+  );
+  const seen = new Set<string>();
+  const threats: SecurityThreatRow[] = [];
+  for (const t of candidates) {
+    if (suppressedKeys.has(t.threatKey)) continue;
+    const fingerprint = threatDisplayFingerprint(t);
+    if (suppressedFingerprints.has(fingerprint)) continue;
+    if (seen.has(fingerprint)) continue;
+    seen.add(fingerprint);
+    threats.push(t);
+    if (threats.length >= 12) break;
+  }
+  return threats;
 }
 
 function p50Latency(records: ProxyCallRecord[]): number | null {
@@ -151,6 +212,7 @@ export async function buildSecurityDashboard(
     executiveSummary: ['Start the Mastyf AI proxy and route MCP traffic to populate live threat data.'],
     threats: [],
     activeThreatCount: 0,
+    quarantinedCount: 0,
     semanticEngineActive: semStats.enabled,
     autoBlockOn: opts?.policyMode === 'block',
     auditLatencyMs: null,
@@ -169,21 +231,10 @@ export async function buildSecurityDashboard(
 
   const records = await loadAllRecordsInWindow(db, tenantId, windowDays);
   const sum = summarizeRecords(records);
-  const blocked = records.filter((r) => r.blocked);
   const quarantine = getSecurityThreatQuarantine(tenantId);
-  const suppressed = quarantine.quarantinedKeys();
-  const semanticThreats = await buildThreatsFromSemantic(tenantId);
-  const recordThreats = buildThreatsFromRecords(blocked);
-  const seen = new Set<string>();
-  const threats: SecurityThreatRow[] = [];
-  for (const t of [...semanticThreats, ...recordThreats]) {
-    if (suppressed.has(t.threatKey)) continue;
-    const key = `${t.type}:${t.source}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    threats.push(t);
-    if (threats.length >= 12) break;
-  }
+  const candidates = await gatherThreatCandidates(db, tenantId, windowDays);
+  const threats = applyThreatVisibilityFilter(candidates, quarantine);
+  const semanticThreats = candidates.filter((t) => t.threatKey.startsWith('semantic:'));
 
   let manifestScore: number | null = null;
   let scanned = 0;
@@ -222,6 +273,22 @@ export async function buildSecurityDashboard(
   const authIntegrity =
     sum.total > 0 ? Math.round((sum.passed / sum.total) * 1000) / 10 : 100;
 
+  const quarantinedEntries = quarantine.list(365);
+  const quarantinedCount = quarantinedEntries.length;
+  const quarantinedGroups = new Set(
+    quarantinedEntries.map((e) => threatDisplayFingerprint(e)),
+  ).size;
+
+  const summaryLines = [
+    sum.blocked > 0
+      ? `${sum.blocked} policy blocks in last ${windowDays >= 1 ? Math.round(windowDays * 24) + 'h' : 'window'}`
+      : 'No blocks recorded in the selected window',
+    quarantinedGroups > 0
+      ? `${quarantinedGroups} threat group(s) quarantined (${quarantinedCount} archived) — restore from Quarantine tab to return to Active Threats`
+      : null,
+    `Auth layer integrity: ${authIntegrity}%`,
+  ].filter((line): line is string => !!line);
+
   return {
     available: true,
     windowDays,
@@ -229,14 +296,10 @@ export async function buildSecurityDashboard(
     securityScore,
     scoreLabel: scoreLabel(securityScore),
     layers,
-    executiveSummary: [
-      sum.blocked > 0
-        ? `${sum.blocked} threats blocked in last ${windowDays >= 1 ? Math.round(windowDays * 24) + 'h' : 'window'}`
-        : 'No blocks recorded in the selected window',
-      `Auth layer integrity: ${authIntegrity}%`,
-    ],
+    executiveSummary: summaryLines,
     threats,
     activeThreatCount: threats.filter((t) => t.status !== 'resolved').length,
+    quarantinedCount,
     semanticEngineActive: semStats.enabled,
     autoBlockOn: opts?.policyMode === 'block',
     auditLatencyMs: p50Latency(records),

--- a/src/utils/security-threat-quarantine.ts
+++ b/src/utils/security-threat-quarantine.ts
@@ -134,14 +134,36 @@ export class SecurityThreatQuarantine {
   }
 
   restore(threatKey: string): { ok: boolean; error?: string; record?: SecurityQuarantineRecord } {
+    const group = this.restoreGroup(threatKey);
+    if (!group.ok) return { ok: false, error: group.error };
+    return { ok: true, record: group.records?.[0] };
+  }
+
+  /**
+   * Restore every quarantined row that shares type+source with the anchor threat.
+   * Matches bulk quarantine, which archives all underlying rows for a fingerprint.
+   */
+  restoreGroup(
+    threatKey: string,
+  ): { ok: boolean; error?: string; records?: SecurityQuarantineRecord[]; restored?: number } {
     const state = this.read();
-    const idx = state.entries.findIndex(
+    const anchor = state.entries.find(
       (e) => e.threatKey === threatKey || e.id === threatKey,
     );
-    if (idx < 0) return { ok: false, error: 'Not in quarantine' };
-    const [record] = state.entries.splice(idx, 1);
-    saveState(this.tenantId, state);
-    return { ok: true, record };
+    if (!anchor) return { ok: false, error: 'Not in quarantine' };
+    const fingerprint = `${anchor.type}:${anchor.source}`;
+    const removed: SecurityQuarantineRecord[] = [];
+    const kept: SecurityQuarantineRecord[] = [];
+    for (const entry of state.entries) {
+      if (`${entry.type}:${entry.source}` === fingerprint) {
+        removed.push(entry);
+      } else {
+        kept.push(entry);
+      }
+    }
+    if (removed.length === 0) return { ok: false, error: 'Not in quarantine' };
+    saveState(this.tenantId, { entries: kept });
+    return { ok: true, records: removed, restored: removed.length };
   }
 
   list(days = 30): SecurityQuarantineRecord[] {

--- a/tests/utils/security-dashboard.test.ts
+++ b/tests/utils/security-dashboard.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { buildSecurityDashboard } from '../../src/utils/security-dashboard.js';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  buildSecurityDashboard,
+  filterVisibleMonitorThreats,
+  threatDisplayFingerprint,
+  type SecurityThreatRow,
+} from '../../src/utils/security-dashboard.js';
+import {
+  getSecurityThreatQuarantine,
+  resetSecurityThreatQuarantineForTests,
+} from '../../src/utils/security-threat-quarantine.js';
 
 describe('buildSecurityDashboard', () => {
   it('returns empty-state payload without database', async () => {
@@ -7,5 +19,49 @@ describe('buildSecurityDashboard', () => {
     expect(payload.available).toBe(false);
     expect(payload.threats).toEqual([]);
     expect(payload.layers).toHaveLength(4);
+  });
+});
+
+describe('filterVisibleMonitorThreats', () => {
+  let home: string;
+  const prevHome = process.env.MASTYF_AI_HOME;
+
+  beforeEach(() => {
+    resetSecurityThreatQuarantineForTests();
+    home = mkdtempSync(join(tmpdir(), 'mastyf-ai-sec-dash-'));
+    process.env.MASTYF_AI_HOME = home;
+  });
+
+  afterEach(() => {
+    resetSecurityThreatQuarantineForTests();
+    if (prevHome === undefined) delete process.env.MASTYF_AI_HOME;
+    else process.env.MASTYF_AI_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('hides sibling threats that share type and source after one quarantine', () => {
+    const rowA: SecurityThreatRow = {
+      id: 'THR-1',
+      threatKey: 'block:fs:read:2026-07-03 10:55:17',
+      type: 'Semantic Prompt Injection',
+      source: '10.13.195.218',
+      severity: 'critical',
+      status: 'blocked',
+    };
+    const rowB: SecurityThreatRow = {
+      id: 'THR-2',
+      threatKey: 'block:fs:read:2026-07-03 10:55:19',
+      type: 'Semantic Prompt Injection',
+      source: '10.13.195.218',
+      severity: 'critical',
+      status: 'blocked',
+    };
+    expect(threatDisplayFingerprint(rowA)).toBe(threatDisplayFingerprint(rowB));
+
+    const store = getSecurityThreatQuarantine('default');
+    store.quarantine(rowA);
+
+    const visible = filterVisibleMonitorThreats([rowA, rowB], store);
+    expect(visible).toEqual([]);
   });
 });

--- a/tests/utils/security-threat-quarantine.test.ts
+++ b/tests/utils/security-threat-quarantine.test.ts
@@ -75,6 +75,31 @@ describe('SecurityThreatQuarantine', () => {
     expect(q.findEntry(30, { id: 'THR-3450' })?.threatKey).toBe(threatKey);
   });
 
+  it('restoreGroup removes all rows that share type and source', () => {
+    const q = new SecurityThreatQuarantine('default');
+    const shared = {
+      type: 'Semantic Prompt Injection',
+      source: '10.13.195.218',
+      severity: 'critical' as const,
+      status: 'blocked' as const,
+    };
+    q.quarantine({
+      id: 'THR-1',
+      threatKey: 'block:fs:read:2026-07-03 10:55:17',
+      ...shared,
+    });
+    q.quarantine({
+      id: 'THR-2',
+      threatKey: 'block:fs:read:2026-07-03 10:55:19',
+      ...shared,
+    });
+    expect(q.list(30)).toHaveLength(2);
+    const restored = q.restoreGroup('block:fs:read:2026-07-03 10:55:17');
+    expect(restored.ok).toBe(true);
+    expect(restored.restored).toBe(2);
+    expect(q.list(30)).toHaveLength(0);
+  });
+
   it('stores enforcement metadata', () => {
     const q = new SecurityThreatQuarantine('default');
     const row = {


### PR DESCRIPTION
Suppress and restore threat groups by type+source fingerprint so quarantine-all and restore stay in sync, expand bulk quarantine to archive all underlying rows, and clarify the dashboard when active threats are hidden by quarantine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security quarantine/restore API behavior and YAML rule removal paths; mistakes could leave threats visible or over-archive related rows, though unit tests cover fingerprint filtering and group restore.
> 
> **Overview**
> Threat monitor quarantine now treats **type+source** as a stable **fingerprint** so the UI, dashboard API, and quarantine store stay aligned when multiple block/semantic rows collapse to one visible row.
> 
> **Quarantine** expands single actions and **Quarantine All** to archive every underlying candidate that shares that fingerprint (not just the displayed row), using `listMonitorThreatCandidates` and `threatDisplayFingerprint`. **Restore** calls `restoreGroup` to remove all quarantined entries in the same group and returns a `restored` count; optional policy rule removal still uses the primary restored record.
> 
> **Active Threats** visibility hides rows whose `threatKey` is quarantined or whose fingerprint matches any quarantined entry. The security dashboard adds **`quarantinedCount`**, executive-summary lines for quarantined groups, and clearer empty states when threats are hidden by quarantine or when policy blocks exist without high-severity monitor rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7276506428fe3a44374bf5a7425e6ff141189e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->