### PR TITLE
Fix security threat quarantine window mismatch with dashboard

### DIFF
--- a/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
+++ b/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
@@ -161,7 +161,7 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
     if (!count) { onAction?.('No high-severity threats to quarantine'); return; }
     if (!window.confirm(`Quarantine ${count} high/critical threat(s)?`)) return;
     setBusy('quarantine-all');
-    const res = await quarantineAllThreats();
+    const res = await quarantineAllThreats(windowParam);
     if (res.ok) {
       onAction?.(`Quarantined ${res.quarantined ?? 0} threat(s). See Security → Quarantine for enforcement status and applied YAML rules.`);
       await load();
@@ -175,7 +175,7 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
     if (!canMutate) { onAction?.('Requires operator role'); return; }
     if (!window.confirm(`Quarantine ${row.id}?`)) return;
     setBusy(row.id);
-    const res = await quarantineSecurityThreat(row);
+    const res = await quarantineSecurityThreat(row, undefined, windowParam);
     if (res.ok) {
       onAction?.(formatQuarantineResultMessage(row.id, {
         enforcementStatus: res.enforcementStatus,

--- a/deploy/dashboard-spa/app/components/security/SecurityDashboardPanel.tsx
+++ b/deploy/dashboard-spa/app/components/security/SecurityDashboardPanel.tsx
@@ -72,7 +72,7 @@ export function SecurityDashboardPanel({ refreshKey = 0, roles = [], onNavigate,
       return;
     }
     setBusy('quarantine-all');
-    const res = await quarantineAllThreats();
+    const res = await quarantineAllThreats('24h');
     if (res.ok) {
       onAction?.(`Quarantined ${res.quarantined ?? 0} threat(s) with enforcement checks — see Security → Quarantined`);
       await load();
@@ -96,7 +96,7 @@ export function SecurityDashboardPanel({ refreshKey = 0, roles = [], onNavigate,
     }
     const payload = { ...row, threatKey: row.threatKey || row.id };
     setBusy(payload.threatKey);
-    const res = await quarantineSecurityThreat(payload);
+    const res = await quarantineSecurityThreat(payload, undefined, '24h');
     if (res.ok) {
       if (res.enforcementStatus === 'applied') {
         onAction?.(`Quarantined ${row.id}. Applied policy rule ${res.appliedRuleName || 'for threat hardening'}.`);

--- a/deploy/dashboard-spa/lib/mastyf-ai-api.ts
+++ b/deploy/dashboard-spa/lib/mastyf-ai-api.ts
@@ -2311,7 +2311,9 @@ export async function fetchSecurityDashboard(
   return (await res.json()) as SecurityDashboardResponse;
 }
 
-export async function quarantineAllThreats(): Promise<{
+export async function quarantineAllThreats(
+  window: string = '7d',
+): Promise<{
   ok: boolean;
   quarantined?: number;
   error?: string;
@@ -2320,7 +2322,7 @@ export async function quarantineAllThreats(): Promise<{
   const res = await mastyfAiFetch('/api/security/threats/quarantine', {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ all: true }),
+    body: JSON.stringify({ all: true, window }),
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };
@@ -2332,6 +2334,7 @@ export async function quarantineAllThreats(): Promise<{
 export async function quarantineSecurityThreat(
   row: SecurityDashboardThreat,
   note?: string,
+  window: string = '7d',
 ): Promise<{
   ok: boolean;
   error?: string;
@@ -2342,7 +2345,7 @@ export async function quarantineSecurityThreat(
   const res = await mastyfAiFetch('/api/security/threats/quarantine', {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...row, note }),
+    body: JSON.stringify({ ...row, note, window }),
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };

--- a/src/utils/dashboard-server.ts
+++ b/src/utils/dashboard-server.ts
@@ -2535,6 +2535,10 @@ export async function startDashboardServer(
         setCors();
         const b = await readBody(req);
         try {
+          const u = new URL(req.url || url, 'http://localhost');
+          const { DEFAULT_SECURITY_MONITOR_WINDOW } = await import('./security-dashboard.js');
+          const monitorWindow = b.window ?? u.searchParams.get('window') ?? DEFAULT_SECURITY_MONITOR_WINDOW;
+          const windowDays = parseWindowDays(monitorWindow);
           const { getSecurityThreatQuarantine } = await import('./security-threat-quarantine.js');
           const { applyMonitorQuarantineEnforcement } = await import('./monitor-quarantine-enforcement.js');
           const store = getSecurityThreatQuarantine(requestTenantId);
@@ -2544,7 +2548,7 @@ export async function startDashboardServer(
             || defaultPolicyPath();
 
           if (b.all === true || b.all === 'true') {
-            const fed = await resolveChartContext(requestTenantId, 1);
+            const fed = await resolveChartContext(requestTenantId, windowDays);
             let policyMode: string | undefined;
             try {
               const { readFileSync } = await import('fs');
@@ -2555,24 +2559,15 @@ export async function startDashboardServer(
             } catch {
               policyMode = process.env.MASTYF_AI_POLICY_MODE;
             }
-            const { buildSecurityDashboard, listMonitorThreatCandidates, threatDisplayFingerprint } =
-              await import('./security-dashboard.js');
-            const dash = await buildSecurityDashboard(fed.db, requestTenantId, 1, { policyMode });
-            const visibleHigh = (dash.threats ?? []).filter(
-              (t) => t.severity === 'critical' || t.severity === 'high',
+            const { listBulkQuarantineTargets } = await import('./security-dashboard.js');
+            const targets = await listBulkQuarantineTargets(
+              fed.db,
+              requestTenantId,
+              monitorWindow,
+              policyMode,
             );
-            const targetFingerprints = new Set(
-              visibleHigh.map((t) => threatDisplayFingerprint(t)),
-            );
-            const allCandidates = await listMonitorThreatCandidates(fed.db, requestTenantId, 1);
-            const targetsByKey = new Map<string, (typeof allCandidates)[number]>();
-            for (const row of allCandidates) {
-              if (row.severity !== 'critical' && row.severity !== 'high') continue;
-              if (!targetFingerprints.has(threatDisplayFingerprint(row))) continue;
-              targetsByKey.set(row.threatKey, row);
-            }
             let quarantined = 0;
-            for (const row of targetsByKey.values()) {
+            for (const row of targets) {
               const enforcement = await applyMonitorQuarantineEnforcement({
                 row,
                 tenantId: requestTenantId,
@@ -2618,14 +2613,14 @@ export async function startDashboardServer(
               ? b.status
               : 'blocked') as 'blocked' | 'monitored' | 'resolved',
           };
-          const fed = await resolveChartContext(requestTenantId, 1);
-          const { listMonitorThreatCandidates, threatDisplayFingerprint } =
-            await import('./security-dashboard.js');
-          const fingerprint = threatDisplayFingerprint(row);
-          const related = (await listMonitorThreatCandidates(fed.db, requestTenantId, 1)).filter(
-            (candidate) => threatDisplayFingerprint(candidate) === fingerprint,
+          const fed = await resolveChartContext(requestTenantId, windowDays);
+          const { listRelatedMonitorThreatsForQuarantine } = await import('./security-dashboard.js');
+          const targets = await listRelatedMonitorThreatsForQuarantine(
+            fed.db,
+            requestTenantId,
+            row,
+            monitorWindow,
           );
-          const targets = related.length > 0 ? related : [row];
           let lastEnforcement: Awaited<ReturnType<typeof applyMonitorQuarantineEnforcement>> | null =
             null;
           let lastResult: ReturnType<typeof store.quarantine> | null = null;

--- a/src/utils/security-dashboard.ts
+++ b/src/utils/security-dashboard.ts
@@ -142,6 +142,9 @@ async function gatherThreatCandidates(
   return [...semanticThreats, ...recordThreats];
 }
 
+/** Matches dashboard time-window selector default (see DashboardWindowContext). */
+export const DEFAULT_SECURITY_MONITOR_WINDOW = '7d';
+
 /** All monitor threat rows before quarantine / dedupe (for bulk quarantine expansion). */
 export async function listMonitorThreatCandidates(
   db: IDatabase | null,
@@ -151,6 +154,56 @@ export async function listMonitorThreatCandidates(
   if (!db) return [];
   const windowDays = parseWindowDays(windowDaysInput);
   return gatherThreatCandidates(db, tenantId, windowDays);
+}
+
+/** Related rows for single quarantine — must use the same window as the active dashboard. */
+export function filterRelatedMonitorThreats(
+  candidates: SecurityThreatRow[],
+  anchor: SecurityThreatRow,
+): SecurityThreatRow[] {
+  const fingerprint = threatDisplayFingerprint(anchor);
+  const related = candidates.filter((candidate) => threatDisplayFingerprint(candidate) === fingerprint);
+  return related.length > 0 ? related : [anchor];
+}
+
+export async function listRelatedMonitorThreatsForQuarantine(
+  db: IDatabase | null,
+  tenantId: string | undefined,
+  anchor: SecurityThreatRow,
+  windowDaysInput: number | string = DEFAULT_SECURITY_MONITOR_WINDOW,
+): Promise<SecurityThreatRow[]> {
+  const candidates = await listMonitorThreatCandidates(db, tenantId, windowDaysInput);
+  return filterRelatedMonitorThreats(candidates, anchor);
+}
+
+/** High/critical rows to archive for quarantine-all — keyed by threatKey within the dashboard window. */
+export function collectBulkQuarantineTargets(
+  candidates: SecurityThreatRow[],
+  visibleThreats: SecurityThreatRow[],
+): SecurityThreatRow[] {
+  const visibleHigh = visibleThreats.filter(
+    (t) => t.severity === 'critical' || t.severity === 'high',
+  );
+  const targetFingerprints = new Set(visibleHigh.map((t) => threatDisplayFingerprint(t)));
+  const targetsByKey = new Map<string, SecurityThreatRow>();
+  for (const row of candidates) {
+    if (row.severity !== 'critical' && row.severity !== 'high') continue;
+    if (!targetFingerprints.has(threatDisplayFingerprint(row))) continue;
+    targetsByKey.set(row.threatKey, row);
+  }
+  return [...targetsByKey.values()];
+}
+
+export async function listBulkQuarantineTargets(
+  db: IDatabase | null,
+  tenantId: string | undefined,
+  windowDaysInput: number | string = DEFAULT_SECURITY_MONITOR_WINDOW,
+  policyMode?: string,
+): Promise<SecurityThreatRow[]> {
+  const windowDays = parseWindowDays(windowDaysInput);
+  const dash = await buildSecurityDashboard(db, tenantId, windowDays, { policyMode });
+  const candidates = await listMonitorThreatCandidates(db, tenantId, windowDaysInput);
+  return collectBulkQuarantineTargets(candidates, dash.threats ?? []);
 }
 
 /** @internal Exported for unit tests — dedupe + quarantine suppression. */

--- a/tests/utils/security-dashboard.test.ts
+++ b/tests/utils/security-dashboard.test.ts
@@ -4,6 +4,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   buildSecurityDashboard,
+  collectBulkQuarantineTargets,
+  filterRelatedMonitorThreats,
   filterVisibleMonitorThreats,
   threatDisplayFingerprint,
   type SecurityThreatRow,
@@ -63,5 +65,83 @@ describe('filterVisibleMonitorThreats', () => {
 
     const visible = filterVisibleMonitorThreats([rowA, rowB], store);
     expect(visible).toEqual([]);
+  });
+});
+
+describe('filterRelatedMonitorThreats', () => {
+  const rowA: SecurityThreatRow = {
+    id: 'THR-1',
+    threatKey: 'block:fs:read:2026-07-01 10:55:17',
+    type: 'Semantic Prompt Injection',
+    source: '10.13.195.218',
+    severity: 'critical',
+    status: 'blocked',
+  };
+  const rowB: SecurityThreatRow = {
+    id: 'THR-2',
+    threatKey: 'block:fs:read:2026-07-03 10:55:19',
+    type: 'Semantic Prompt Injection',
+    source: '10.13.195.218',
+    severity: 'critical',
+    status: 'blocked',
+  };
+  const rowOther: SecurityThreatRow = {
+    id: 'THR-3',
+    threatKey: 'block:db:query:2026-07-03 10:55:19',
+    type: 'SQL Injection Attempt',
+    source: '10.1.2.3',
+    severity: 'high',
+    status: 'blocked',
+  };
+
+  it('returns all fingerprint siblings present in the candidate list', () => {
+    const related = filterRelatedMonitorThreats([rowA, rowB, rowOther], rowA);
+    expect(related).toEqual([rowA, rowB]);
+  });
+
+  it('returns only in-window siblings when the candidate list is window-scoped', () => {
+    const related = filterRelatedMonitorThreats([rowB, rowOther], rowB);
+    expect(related).toEqual([rowB]);
+  });
+
+  it('falls back to the anchor when no siblings are in the candidate list', () => {
+    const related = filterRelatedMonitorThreats([rowOther], rowA);
+    expect(related).toEqual([rowA]);
+  });
+});
+
+describe('collectBulkQuarantineTargets', () => {
+  it('archives every high/critical row for visible fingerprint groups', () => {
+    const visible: SecurityThreatRow[] = [
+      {
+        id: 'THR-1',
+        threatKey: 'semantic:a',
+        type: 'Semantic Prompt Injection',
+        source: '10.1.1.1',
+        severity: 'critical',
+        status: 'blocked',
+      },
+    ];
+    const candidates: SecurityThreatRow[] = [
+      ...visible,
+      {
+        id: 'THR-2',
+        threatKey: 'semantic:b',
+        type: 'Semantic Prompt Injection',
+        source: '10.1.1.1',
+        severity: 'critical',
+        status: 'blocked',
+      },
+      {
+        id: 'THR-3',
+        threatKey: 'block:other',
+        type: 'SQL Injection Attempt',
+        source: '10.2.2.2',
+        severity: 'high',
+        status: 'blocked',
+      },
+    ];
+    const targets = collectBulkQuarantineTargets(candidates, visible);
+    expect(targets.map((t) => t.threatKey).sort()).toEqual(['semantic:a', 'semantic:b']);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a mismatch between the security dashboard display window and quarantine operations.

**Problem:** Single and bulk quarantine used a hardcoded 1-day window to find related threat rows, while the dashboard can show threats across the user-selected window (default 7d). Fingerprint-based visibility suppression then hid sibling threats that were never archived.

**Fix:**
- Accept `window` on `POST /api/security/threats/quarantine` (body or query param), defaulting to `7d`
- Use that window for `resolveChartContext`, related-threat expansion, and bulk quarantine target collection
- Centralize logic in `security-dashboard.ts` helpers: `filterRelatedMonitorThreats`, `listRelatedMonitorThreatsForQuarantine`, `collectBulkQuarantineTargets`, `listBulkQuarantineTargets`
- Pass the dashboard time window from the SPA when quarantining

## Test plan

- [x] `npx vitest run tests/utils/security-dashboard.test.ts` (6 tests pass)
- [ ] Quarantine a threat with dashboard set to 7d — verify all fingerprint siblings in the window are archived
- [ ] Quarantine All with 7d window — verify all visible high/critical groups are archived, not just last-24h rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d57c5aa6-23f5-44b4-9cea-5e0aa9d23532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d57c5aa6-23f5-44b4-9cea-5e0aa9d23532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

