### PR TITLE
Fix restore to remove all quarantine policy rules in a group

### DIFF
--- a/src/utils/dashboard-server.ts
+++ b/src/utils/dashboard-server.ts
@@ -2500,14 +2500,22 @@ export async function startDashboardServer(
           }
           const primary = result.records?.[0];
           let removedRule = false;
-          if (removeRule && primary?.appliedRuleName) {
+          if (removeRule && result.records?.length) {
             const { removeSuggestionRuleFromPolicy } = await import('../ai/policy-applier.js');
-            const removed = removeSuggestionRuleFromPolicy(
-              primary.appliedRuleName,
-              primary.policyPath || defaultPolicyPath(),
-              policyWatcher ?? null,
-            );
-            removedRule = removed.removed;
+            const seenRuleKeys = new Set<string>();
+            for (const record of result.records) {
+              if (!record.appliedRuleName) continue;
+              const policyForRule = record.policyPath || defaultPolicyPath();
+              const ruleKey = `${policyForRule}\0${record.appliedRuleName}`;
+              if (seenRuleKeys.has(ruleKey)) continue;
+              seenRuleKeys.add(ruleKey);
+              const removed = removeSuggestionRuleFromPolicy(
+                record.appliedRuleName,
+                policyForRule,
+                policyWatcher ?? null,
+              );
+              if (removed.removed) removedRule = true;
+            }
           }
           appendThreatIntelActionAudit({
             action: 'monitor_restore',

--- a/tests/dashboard/dashboard-security-threat-quarantine.test.ts
+++ b/tests/dashboard/dashboard-security-threat-quarantine.test.ts
@@ -132,4 +132,64 @@ describe('dashboard security threat quarantine actions', () => {
     const policy = readFileSync(policyPath, 'utf-8');
     expect(policy.includes('quarantine-semantic-restore-1')).toBe(false);
   });
+
+  it('restores monitor group and removes all distinct applied rules', async () => {
+    writeFileSync(policyPath, [
+      'version: "1.0"',
+      'policy:',
+      '  mode: block',
+      '  rules:',
+      '    - name: quarantine-semantic-rule-a',
+      '      action: block',
+      '      patterns: ["prompt-a"]',
+      '    - name: quarantine-semantic-rule-b',
+      '      action: block',
+      '      patterns: ["prompt-b"]',
+      '',
+    ].join('\n'));
+    writeFileSync(quarantinePath, JSON.stringify({
+      entries: [
+        {
+          id: 'THR-G1',
+          threatKey: 'semantic:group-restore-a',
+          type: 'Semantic Prompt Injection',
+          source: '10.1.1.1',
+          severity: 'critical',
+          status: 'resolved',
+          quarantinedAt: new Date().toISOString(),
+          enforcementStatus: 'applied',
+          sourceKind: 'semantic',
+          appliedRuleName: 'quarantine-semantic-rule-a',
+          policyPath,
+        },
+        {
+          id: 'THR-G2',
+          threatKey: 'semantic:group-restore-b',
+          type: 'Semantic Prompt Injection',
+          source: '10.1.1.1',
+          severity: 'critical',
+          status: 'resolved',
+          quarantinedAt: new Date().toISOString(),
+          enforcementStatus: 'applied',
+          sourceKind: 'semantic',
+          appliedRuleName: 'quarantine-semantic-rule-b',
+          policyPath,
+        },
+      ],
+    }, null, 2));
+
+    const restore = await fetch(`http://127.0.0.1:${PORT}/api/security/threats/restore`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ threatKey: 'semantic:group-restore-a', removeRule: true }),
+    });
+    expect(restore.ok).toBe(true);
+    const body = (await restore.json()) as { removedRule?: boolean; restored?: number };
+    expect(body.removedRule).toBe(true);
+    expect(body.restored).toBe(2);
+
+    const policy = readFileSync(policyPath, 'utf-8');
+    expect(policy.includes('quarantine-semantic-rule-a')).toBe(false);
+    expect(policy.includes('quarantine-semantic-rule-b')).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When restoring a quarantined threat group with `removeRule` enabled, the restore endpoint only removed the policy rule from the first record in the group. Bulk quarantine can apply distinct rules for each underlying row that shares the same fingerprint (`type:source`), so related rules were left behind in the policy file.

## Changes

- Iterate over all records returned by `restoreGroup()` and remove each distinct `appliedRuleName` (deduplicated per policy path).
- Add a dashboard integration test that restores a two-row group with different applied rules and verifies both are removed from policy.

## Test plan

- [x] `pnpm exec vitest run tests/dashboard/dashboard-security-threat-quarantine.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525fdcd4-1dc1-435b-a960-faab5793d098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525fdcd4-1dc1-435b-a960-faab5793d098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

