### PR TITLE
Remove bulk Quarantine All from security dashboard and fix macOS setup.

### DIFF
--- a/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
+++ b/deploy/dashboard-spa/app/components/operations/SecurityOperationsCenter.tsx
@@ -20,7 +20,6 @@ import {
   fetchSwarmLatest,
   fetchThreatLabCandidates,
   pollAiThreats,
-  quarantineAllThreats,
   quarantineSecurityThreat,
   quarantineThreatIntel,
   rejectThreatLabCandidate,
@@ -155,22 +154,6 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
   const activeThreats = dash?.activeThreatCount ?? sec?.activeThreats ?? 0;
   const serverCount = sec?.serverReports?.length ?? health?.serverReports?.length ?? 0;
 
-  const onQuarantineAll = async () => {
-    if (!canMutate) { onAction?.('Requires operator role'); return; }
-    const count = (dash?.threats ?? []).filter(t => t.severity === 'critical' || t.severity === 'high').length;
-    if (!count) { onAction?.('No high-severity threats to quarantine'); return; }
-    if (!window.confirm(`Quarantine ${count} high/critical threat(s)?`)) return;
-    setBusy('quarantine-all');
-    const res = await quarantineAllThreats(windowParam);
-    if (res.ok) {
-      onAction?.(`Quarantined ${res.quarantined ?? 0} threat(s). See Security → Quarantine for enforcement status and applied YAML rules.`);
-      await load();
-    } else {
-      onAction?.(res.error || 'Quarantine failed');
-    }
-    setBusy('');
-  };
-
   const onQuarantineOne = async (row: SecurityDashboardThreat) => {
     if (!canMutate) { onAction?.('Requires operator role'); return; }
     if (!window.confirm(`Quarantine ${row.id}?`)) return;
@@ -255,13 +238,6 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
           <Card
             title="Active Threats"
             subtitle={dash?.threats ? `${dash.threats.length} detected` : undefined}
-            actions={
-              <div className="flex gap-2">
-                <Button variant="danger" size="sm" onClick={() => void onQuarantineAll()} disabled={!!busy || !canMutate}>
-                  {busy === 'quarantine-all' ? '…' : 'Quarantine All'}
-                </Button>
-              </div>
-            }
           >
             {loading ? (
               <p className="text-sm text-muted">Loading threats…</p>
@@ -270,7 +246,7 @@ function OverviewView({ roles, refreshKey, onAction }: { roles: string[]; refres
                 title="No active threats"
                 message={
                   (dash?.quarantinedCount ?? 0) > 0
-                    ? `${dash.quarantinedCount} threat(s) are quarantined and hidden from this list. Open Security → Quarantine and click Restore to show them here again.`
+                    ? `${dash?.quarantinedCount ?? 0} threat(s) are quarantined and hidden from this list. Open Security → Quarantine and click Restore to show them here again.`
                     : (dash?.executiveSummary?.[0]?.includes('policy blocks')
                       ? 'Blocks are recorded in the window above, but no high-severity threat rows are in the monitor queue.'
                       : 'All clear — no active threats detected in the selected time window.')

--- a/deploy/dashboard-spa/app/components/security/SecurityDashboardPanel.tsx
+++ b/deploy/dashboard-spa/app/components/security/SecurityDashboardPanel.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   fetchSecurityDashboard,
-  quarantineAllThreats,
   quarantineSecurityThreat,
   type SecurityDashboardResponse,
   type SecurityDashboardThreat,
@@ -51,36 +50,6 @@ export function SecurityDashboardPanel({ refreshKey = 0, roles = [], onNavigate,
   useEffect(() => {
     void load();
   }, [load, refreshKey]);
-
-  const onQuarantineAll = async () => {
-    if (!canMutate) {
-      onAction?.('Requires operator role to quarantine threats');
-      return;
-    }
-    const count = (data?.threats ?? []).filter(
-      (t) => t.severity === 'critical' || t.severity === 'high',
-    ).length;
-    if (!count) {
-      onAction?.('No high-severity threats to quarantine');
-      return;
-    }
-    if (
-      !window.confirm(
-        `Quarantine ${count} high/critical threat(s)? This will hide them from Threat Monitor and apply or confirm hardening policy rules. Quarantined records are listed under Security → Quarantined.`,
-      )
-    ) {
-      return;
-    }
-    setBusy('quarantine-all');
-    const res = await quarantineAllThreats('24h');
-    if (res.ok) {
-      onAction?.(`Quarantined ${res.quarantined ?? 0} threat(s) with enforcement checks — see Security → Quarantined`);
-      await load();
-    } else {
-      onAction?.(res.error || 'Quarantine failed');
-    }
-    setBusy('');
-  };
 
   const onQuarantineOne = async (row: SecurityDashboardThreat) => {
     if (!canMutate) {
@@ -237,14 +206,6 @@ export function SecurityDashboardPanel({ refreshKey = 0, roles = [], onNavigate,
                 <span className="threat-active-badge">{data?.activeThreatCount ?? 0} active</span>
               </h3>
               <div className="btn-row">
-                <Button
-                  variant="primary"
-                  onClick={() => void onQuarantineAll()}
-                  disabled={!!busy || !canMutate}
-                  title={!canMutate ? 'Requires operator role' : undefined}
-                >
-                  {busy === 'quarantine-all' ? 'Quarantining…' : 'Quarantine All'}
-                </Button>
                 <Button variant="secondary" onClick={onExport}>
                   Export
                 </Button>

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,90 @@ step()    { echo -e "\n${CYAN}${BOLD}── $* ${RESET}"; }
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT"
 
+OS="$(uname -s)"
+
+# Never run under sudo — nix must use the installing user's HOME and tokens.
+if [ "$(id -u)" -eq 0 ]; then
+  die "Do not run setup.sh as root. Re-run as your normal user (setup will prompt for sudo only when needed)."
+fi
+
+# Portable in-place sed (GNU vs BSD/macOS).
+sed_inplace() {
+  if sed --version 2>/dev/null | grep -q GNU; then
+    sed -i "$@"
+  else
+    local expr=$1
+    shift
+    sed -i '' "$expr" "$@"
+  fi
+}
+
 # Single canonical nix develop command — no variable expansion, no quoting issues
-NIX_DEVELOP="nix --extra-experimental-features nix-command --extra-experimental-features flakes develop ${ROOT}/config"
+NIX_FLAGS=(--extra-experimental-features nix-command --extra-experimental-features flakes)
+NIX_DEVELOP=(nix "${NIX_FLAGS[@]}" develop "${ROOT}/config")
+
+nix_store_ping() {
+  nix "${NIX_FLAGS[@]}" store ping &>/dev/null
+}
+
+nix_daemon_running() {
+  if [ "$OS" = "Darwin" ]; then
+    if launchctl print system/systems.determinate.nix-daemon &>/dev/null; then
+      launchctl print system/systems.determinate.nix-daemon 2>/dev/null | grep -q 'state = running'
+      return
+    fi
+    if launchctl print system/org.nixos.nix-daemon &>/dev/null; then
+      launchctl print system/org.nixos.nix-daemon 2>/dev/null | grep -q 'state = running'
+      return
+    fi
+    return 1
+  fi
+  systemctl is-active --quiet nix-daemon 2>/dev/null
+}
+
+start_nix_daemon() {
+  if [ "$OS" = "Darwin" ]; then
+    # Determinate Nix manages 3.x (launchd). Never `sudo nix-daemon &` — it breaks HOME and sockets.
+    if launchctl print system/systems.determinate.nix-daemon &>/dev/null; then
+      sudo launchctl kickstart -k system/systems.determinate.nix-daemon
+      return
+    fi
+    if launchctl print system/org.nixos.nix-daemon &>/dev/null; then
+      sudo launchctl kickstart -k system/org.nixos.nix-daemon
+      return
+    fi
+    die "Nix launchd service not found. Reinstall via: curl -sSf -L https://install.determinate.systems/nix | sh -s -- install"
+  fi
+  sudo systemctl start nix-daemon
+}
+
+ensure_nix_daemon() {
+  if nix_store_ping; then
+    success "nix-daemon reachable"
+    return
+  fi
+
+  # Orphan `sudo nix-daemon &` from older setup.sh leaves a dead socket on macOS.
+  if [ "$OS" = "Darwin" ] && pgrep -x nix-daemon >/dev/null 2>&1; then
+    warn "Stopping orphan nix-daemon process(es) (macOS uses Determinate launchd)..."
+    sudo pkill -x nix-daemon 2>/dev/null || true
+    sleep 1
+  fi
+
+  if nix_daemon_running; then
+    warn "Daemon launchd job is running but store ping failed — restarting via launchctl..."
+  else
+    warn "nix-daemon not running. Starting it..."
+  fi
+
+  start_nix_daemon
+  sleep 2
+
+  if ! nix_store_ping; then
+    die "Cannot connect to nix-daemon after restart. Run manually:\n  sudo pkill -x nix-daemon\n  sudo launchctl kickstart -k system/systems.determinate.nix-daemon\n  nix store ping --extra-experimental-features 'nix-command flakes'"
+  fi
+  success "nix-daemon started"
+}
 
 # ── Detect shell rc file ──────────────────────────────────────────────────────
 detect_shell_rc() {
@@ -49,14 +131,7 @@ fi
 # ── 2. Ensure nix daemon is running ──────────────────────────────────────────
 step "Checking Nix daemon"
 
-if ! systemctl is-active --quiet nix-daemon 2>/dev/null; then
-  warn "nix-daemon not running. Starting it..."
-  sudo systemctl start nix-daemon 2>/dev/null || sudo nix-daemon &
-  sleep 2
-  success "nix-daemon started"
-else
-  success "nix-daemon is running"
-fi
+ensure_nix_daemon
 
 # ── 3. Grant daemon socket access ────────────────────────────────────────────
 step "Checking nix daemon socket access"
@@ -86,7 +161,7 @@ step "Checking Nix flakes support"
 
 NIX_CONF="${XDG_CONFIG_HOME:-$HOME/.config}/nix/nix.conf"
 
-if ! nix --extra-experimental-features "nix-command flakes" store ping &>/dev/null; then
+if ! nix_store_ping; then
   warn "Enabling flakes in $NIX_CONF..."
   mkdir -p "$(dirname "$NIX_CONF")"
   if ! grep -q "experimental-features" "$NIX_CONF" 2>/dev/null; then
@@ -94,6 +169,9 @@ if ! nix --extra-experimental-features "nix-command flakes" store ping &>/dev/nu
     success "Flakes enabled"
   else
     warn "experimental-features already present in $NIX_CONF — check for conflicts with /etc/nix/nix.conf"
+  fi
+  if ! nix_store_ping; then
+    ensure_nix_daemon
   fi
 else
   success "Flakes available"
@@ -104,7 +182,7 @@ step "Entering nix dev shell and building"
 
 info "This may take a few minutes on first run (downloading nixpkgs)..."
 
-$NIX_DEVELOP --command bash -euo pipefail << NIXSHELL
+"${NIX_DEVELOP[@]}" --command bash -euo pipefail << NIXSHELL
 BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
 info()    { echo -e "\${BOLD}[setup]\${RESET} \$*"; }
 success() { echo -e "\${GREEN}[setup] ✓\${RESET} \$*"; }
@@ -153,8 +231,8 @@ ALIAS_MARKER="# mastyf.ai alias"
 
 # Remove any old/broken mastyf alias first
 if grep -q "mastyf" "$SHELL_RC" 2>/dev/null; then
-  sed -i '/# mastyf.ai alias/,+1d' "$SHELL_RC"
-  sed -i '/alias mastyf=/d' "$SHELL_RC"
+  sed_inplace '/# mastyf.ai alias/,+1d' "$SHELL_RC"
+  sed_inplace '/alias mastyf=/d' "$SHELL_RC"
 fi
 
 {

--- a/src/utils/dashboard-server.ts
+++ b/src/utils/dashboard-server.ts
@@ -2545,7 +2545,10 @@ export async function startDashboardServer(
         try {
           const u = new URL(req.url || url, 'http://localhost');
           const { DEFAULT_SECURITY_MONITOR_WINDOW } = await import('./security-dashboard.js');
-          const monitorWindow = b.window ?? u.searchParams.get('window') ?? DEFAULT_SECURITY_MONITOR_WINDOW;
+          const monitorWindow: string | number =
+            typeof b.window === 'string' || typeof b.window === 'number'
+              ? b.window
+              : (u.searchParams.get('window') ?? DEFAULT_SECURITY_MONITOR_WINDOW);
           const windowDays = parseWindowDays(monitorWindow);
           const { getSecurityThreatQuarantine } = await import('./security-threat-quarantine.js');
           const { applyMonitorQuarantineEnforcement } = await import('./monitor-quarantine-enforcement.js');


### PR DESCRIPTION
Drop the Quarantine All control from SOC and Security dashboard panels while keeping per-threat quarantine. Harden setup.sh for Determinate Nix on macOS, and type monitorWindow in dashboard-server for TypeScript build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI removal and dev setup; backend bulk quarantine via `all` may still exist but is no longer exposed in these panels.
> 
> **Overview**
> Removes **Quarantine All** from the SOC overview and Security dashboard Threat Monitor. Operators can still quarantine individual threats; the bulk control and `quarantineAllThreats` client usage are gone.
> 
> **setup.sh** is updated for Determinate Nix on macOS: refuses root, uses portable `sed_inplace`, starts/restarts the daemon via **launchctl** (not `sudo nix-daemon &`), kills orphan daemons, and re-checks the store after enabling flakes. Linux still uses **systemctl**.
> 
> **dashboard-server** narrows `monitorWindow` on the quarantine POST route to `string | number` for TypeScript. The SOC empty-state quarantined count message uses optional chaining on `dash`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad76e04ac6ea110f6f7f8e5d8f220350b5f7ba7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->