### PR TITLE
Fix compliance evidence, KPI display, risk scoring, and tool configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/mastyf-ai/mastyf.ai/actions"><img src="https://img.shields.io/badge/CI-passing-22C55E?style=for-the-badge&logo=githubactions&logoColor=white" alt="CI"></a>
   <a href="coverage/lcov-report/index.html"><img src="https://img.shields.io/badge/coverage-58%25-EAB308?style=for-the-badge" alt="Coverage"></a>
   <img src="https://img.shields.io/badge/version-4.1.7-3B82F6?style=for-the-badge" alt="Version">
+  <img src="https://img.shields.io/npm/dm/@mastyf-ai/server?style=for-the-badge&logo=npm&label=downloads&color=CB3837" alt="Downloads">
 </p>
 
 ---

--- a/deploy/dashboard-spa/app/components/agentic/AgenticOperationsPanel.tsx
+++ b/deploy/dashboard-spa/app/components/agentic/AgenticOperationsPanel.tsx
@@ -30,7 +30,7 @@ export function AgenticOperationsPanel({ refreshKey = 0 }: Props) {
   }, [refreshKey, data?.generatedAt]);
 
   const stats = tasks?.stats ?? data?.kpis;
-  const unavailable = tasks?.available === false || data?.available === false || !stats;
+  const unavailable = tasks?.available === false || data?.available === false || !stats || !!data?.emptyReason;
 
   return (
     <div className="agentic-panel space-y-4">

--- a/deploy/dashboard-spa/app/components/agentic/AgenticOverviewPanel.tsx
+++ b/deploy/dashboard-spa/app/components/agentic/AgenticOverviewPanel.tsx
@@ -29,7 +29,7 @@ export function AgenticOverviewPanel({ refreshKey = 0 }: Props) {
   const { setWindow } = useDashboardWindow();
   const { data, loading, error, reload } = useAgenticDashboard(refreshKey, 10_000);
   const kpis = data?.kpis;
-  const unavailable = data?.available === false || !kpis;
+  const unavailable = data?.available === false || !kpis || !!data?.emptyReason;
 
   const trafficData = useMemo(
     () =>

--- a/deploy/dashboard-spa/app/components/agentic/AgenticPolicyPanel.tsx
+++ b/deploy/dashboard-spa/app/components/agentic/AgenticPolicyPanel.tsx
@@ -13,7 +13,7 @@ export function AgenticPolicyPanel({ refreshKey = 0 }: Props) {
   const { data, loading } = useAgenticDashboard(refreshKey);
   const pg = data?.policyGen;
   const frameworks = data?.compliance?.frameworks ?? [];
-  const unavailable = data?.available === false;
+  const unavailable = data?.available === false || !!data?.emptyReason;
 
   if (loading && !data) return <p className="hint p-6">Loading policy &amp; compliance…</p>;
 

--- a/deploy/dashboard-spa/app/components/agentic/AgenticToolsPanel.tsx
+++ b/deploy/dashboard-spa/app/components/agentic/AgenticToolsPanel.tsx
@@ -11,8 +11,8 @@ const TOOL_GROUPS = [
       { id: 'policy-gen', label: 'Generate policy', path: '/api/agentic/policy-gen/generate' },
       { id: 'policy-start', label: 'Start observation', path: '/api/agentic/policy-gen/start-observation' },
       { id: 'policy-stop', label: 'Stop observation', path: '/api/agentic/policy-gen/stop-observation' },
-      { id: 'injection-scan', label: 'Run injection scan', path: '/api/agentic/prompt-injection/scan' },
-      { id: 'dlp-scan', label: 'Run response DLP', path: '/api/agentic/dlp/scan' },
+      { id: 'injection-scan', label: 'Test injection scan', path: '/api/agentic/prompt-injection/scan', body: { toolName: 'read_file', arguments: { content: 'test input' } } },
+      { id: 'dlp-scan', label: 'Test response DLP', path: '/api/agentic/dlp/scan', body: { responseText: 'sample response' } },
     ],
   },
   {
@@ -28,8 +28,8 @@ const TOOL_GROUPS = [
     title: 'Research (lab)',
     tools: [
       { id: 'red-team', label: 'Run red team', path: '/api/agentic/red-team/run' },
-      { id: 'collusion', label: 'Collusion scan', path: '/api/agentic/collusion/detect' },
-      { id: 'thompson', label: 'Evaluate agent trust', path: '/api/agentic/rl/thompson' },
+      { id: 'collusion', label: 'Collusion scan', path: '/api/agentic/collusion/detect', body: { serverName: 'filesystem', toolName: 'read_file' } },
+      { id: 'thompson', label: 'Evaluate agent trust', path: '/api/agentic/rl/thompson', body: { agentId: 'dashboard' } },
       { id: 'certify', label: 'Certify server', path: '/api/agentic/certification/certify', body: { serverName: 'filesystem', packageName: '@modelcontextprotocol/server-filesystem', version: 'latest', trustScore: 70, complianceScore: 50, cveFree: true, authMethod: 'none', transport: 'stdio', trustedPublisher: true } },
     ],
   },

--- a/deploy/dashboard-spa/lib/mastyf-ai-api.ts
+++ b/deploy/dashboard-spa/lib/mastyf-ai-api.ts
@@ -3034,6 +3034,7 @@ export async function fetchCertificationRegistry(): Promise<{
   const res = await mastyfAiFetch('/api/certification/registry');
   if (!res.ok) return null;
   const body = (await res.json()) as {
+    available?: boolean;
     certifications?: Array<{
       serverName: string;
       packageName: string;
@@ -3044,9 +3045,11 @@ export async function fetchCertificationRegistry(): Promise<{
     }>;
     count?: number;
   };
+  if (body.available === false) return null;
+  if (!Array.isArray(body.certifications)) return null;
   return {
-    certifications: Array.isArray(body.certifications) ? body.certifications : [],
-    count: typeof body.count === 'number' ? body.count : body.certifications?.length ?? 0,
+    certifications: body.certifications,
+    count: typeof body.count === 'number' ? body.count : body.certifications.length,
   };
 }
 

--- a/mastyf-ai-configs/fleet-manifest-remote.json
+++ b/mastyf-ai-configs/fleet-manifest-remote.json
@@ -1,15 +1,23 @@
 {
   "mcpServers": {
     "filesystem-proxy": {
-      "url": "http://127.0.0.1:9108/sse",
+      "url": "http://127.0.0.1:9107/sse",
       "transport": "stdio",
       "env": {
         "MASTYF_AI_STREAMABLE_HTTP_PORT": "9107",
         "MASTYF_AI_SSE_PROXY_PORT": "9107"
       }
     },
+    "fixture_echo": {
+      "url": "http://127.0.0.1:9101/mcp",
+      "transport": "stdio",
+      "env": {
+        "MASTYF_AI_STREAMABLE_HTTP_PORT": "9101",
+        "MASTYF_AI_SSE_PROXY_PORT": "9101"
+      }
+    },
     "github-proxy": {
-      "url": "http://127.0.0.1:9109/sse",
+      "url": "http://127.0.0.1:9108/sse",
       "transport": "stdio",
       "env": {
         "MASTYF_AI_STREAMABLE_HTTP_PORT": "9108",
@@ -17,7 +25,7 @@
       }
     },
     "mcp-guardian": {
-      "url": "http://127.0.0.1:9103/mcp",
+      "url": "http://127.0.0.1:9109/mcp",
       "transport": "stdio",
       "env": {
         "MASTYF_AI_STREAMABLE_HTTP_PORT": "9109",

--- a/scenarios/real-life/proxy-filesystem-config.json
+++ b/scenarios/real-life/proxy-filesystem-config.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "official-filesystem": {
-      "command": "/nix/store/nlqqkmmqgv83vgzlahi2sbxk89s7lrmr-nodejs-slim-22.23.1/bin/node",
+      "command": "/Users/rudraneeldas/.nvm/versions/node/v23.11.0/bin/node",
       "args": [
         "/Users/rudraneeldas/mastyf.ai/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
-        "/tmp/nix-shell.o6szx0/mastyf-ai-real-life-GHWrVz"
+        "/var/folders/8k/zjxbk9cj4q369h37ybgy6r7c0000gn/T/mastyf-ai-real-life-Lo7S5V"
       ],
       "env": {},
       "transport": "stdio"

--- a/src/agentic/compliance/compliance-evidence-runner.ts
+++ b/src/agentic/compliance/compliance-evidence-runner.ts
@@ -110,6 +110,7 @@ export class ComplianceEvidenceRunner {
     const policySignals = extractPolicySignals(policyPath);
     const activePolicies = policyTokens(policySignals);
     const auditCounts = await collectAuditCounts(this.db);
+    const hasCvEs = auditCounts.securityScans.some(s => s.cveCount > 0);
     const blockedIncidents = [
       'shell_injection',
       'path_traversal',
@@ -117,14 +118,9 @@ export class ComplianceEvidenceRunner {
       'credential_leak',
       auditCounts.blockedCalls > 0 ? 'incident' : '',
       auditCounts.blockedCalls > 0 ? 'respond' : '',
-      auditCounts.totalCalls > 0 ? 'event' : '',
-      auditCounts.totalCalls > 0 ? 'logging' : '',
-      auditCounts.totalCalls > 0 ? 'audit' : '',
-      auditCounts.securityScans.length > 0 ? 'vulnerability' : '',
-      auditCounts.securityScans.length > 0 ? 'cve' : '',
-      auditCounts.securityScans.length > 0 ? 'scan' : '',
-      activePolicies.some(p => /audit|log/i.test(p)) ? 'audit' : '',
-      activePolicies.some(p => /webhook|alert/i.test(p)) ? 'webhook' : '',
+      hasCvEs ? 'vulnerability' : '',
+      hasCvEs ? 'cve' : '',
+      hasCvEs ? 'scan' : '',
     ].filter(Boolean);
 
     const posture = this.mapper.evaluate(framework, activePolicies, blockedIncidents);

--- a/src/agentic/threat-prediction/risk-scorer.ts
+++ b/src/agentic/threat-prediction/risk-scorer.ts
@@ -87,8 +87,10 @@ export class RiskScorer {
       details: authScore > 50 ? 'Weak or missing authentication' : 'Strong authentication configured',
     });
 
-    // Compute weighted overall score
-    const overallScore = factors.reduce((sum, f) => sum + f.score * f.weight, 0);
+    // Compute weighted overall score (normalize so weights always sum to 1)
+    const totalWeight = factors.reduce((sum, f) => sum + f.weight, 0);
+    const norm = totalWeight > 0 ? 1 / totalWeight : 1;
+    const overallScore = factors.reduce((sum, f) => sum + f.score * f.weight * norm, 0);
 
     // Determine tier
     const tier = this.determineTier(overallScore);


### PR DESCRIPTION
- Remove fake generic incident signals from compliance evidence runner; gate vulnerability signals on actual CVE presence
- Handle unavailable-envelope response in certification registry fetch
- Show 'Unavailable' instead of zero in Agentic KPI panels (Overview, Policy, Operations)
- Restore required JSON body fields in AgenticToolsPanel for injection-scan, dlp-scan, collusion, thompson tools
- Normalize risk scorer weights dynamically when velocityScore is null
- Update MCP config files for remote fleet and filesystem proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compliance evidence logic changes can shift reported framework posture; the scenario config embeds machine-specific paths that may break shared CI or other developers if merged unintentionally.
> 
> **Overview**
> Tightens **compliance evidence** so framework posture is driven by real signals: vulnerability/CVE/scan incident tokens only when security scans report `cveCount > 0`, and removes broad tokens that were inferred from any traffic, scans without CVEs, or policy text alone (generic event/logging/audit/webhook).
> 
> **Agentic dashboard** KPIs on Overview, Policy, and Operations now treat `data.emptyReason` like a missing backend and show **Unavailable** instead of zeros. **Admin tools** send the required POST bodies again for injection scan, DLP, collusion, and Thompson trust (labels reframed as “Test …”). **Certification registry** fetch returns `null` when the API sets `available: false` or omits a certifications array.
> 
> **Threat prediction** re-normalizes risk factor weights when release velocity is unmeasured (weight 0), so the composite score is not diluted. **README** adds an npm downloads badge.
> 
> **MCP configs**: remote fleet manifest remaps proxy ports and adds `fixture_echo`; the real-life filesystem scenario JSON switches to developer-local Node paths and temp dirs (environment-specific).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a7750c1bac11e0e193d3268b2223eb470ec593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->